### PR TITLE
docs: document the run upload workflow in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,33 @@ environment variable.
 
 ### Adding New Data
 
-When adding new experimental runs:
+#### Uploading from the rig (normal path)
 
-1. Add run folder to `run_data/YY.MM.DD_run_X_HHhMM/`
+Runs recorded by [SHIELD_DAS](https://github.com/PTTEPxMIT/SHIELD_DAS) are
+uploaded from the rig computer by hand after each run:
+
+1. When the run has finished, double-click **`upload_runs.bat`** in the
+   SHIELD_DAS folder on the rig PC (or run `shield-das-upload` in a
+   terminal).
+2. The uploader finds every completed run not yet uploaded, renames
+   `shield_data.csv` to `pressure_gauge_data.csv`, drops the `backup/`
+   directory, and opens one pull request per run against this repository
+   (branch `auto/run-<run_id>`, folder `run_data/YY.MM.DD_run_X_HHhMM/`).
+   Already-uploaded runs are skipped, so running it any time is safe.
+3. Review and merge the PR once CI validation passes.
+4. After merge, CI rebuilds the database and updates the
+   [`data-latest` release](https://github.com/PTTEPxMIT/SHIELD-Data/releases/tag/data-latest);
+   `shield_data.update_database()` then picks it up.
+
+One-time setup (GitHub token + config) is documented in
+[SHIELD_DAS docs/auto_upload.md](https://github.com/PTTEPxMIT/SHIELD_DAS/blob/main/docs/auto_upload.md).
+
+#### Adding a run manually
+
+For runs coming from anywhere else:
+
+1. Copy the run folder to `run_data/YY.MM.DD_run_X_HHhMM/` containing
+   `pressure_gauge_data.csv` and `run_metadata.json` (no `backup/` directory)
 2. Commit the run folder and submit a PR (see [CONTRIBUTING.md](CONTRIBUTING.md))
 3. After merge, CI rebuilds the database and updates the `data-latest` release
 

--- a/README.md
+++ b/README.md
@@ -170,11 +170,12 @@ uploaded from the rig computer by hand after each run:
 1. When the run has finished, double-click **`upload_runs.bat`** in the
    SHIELD_DAS folder on the rig PC (or run `shield-das-upload` in a
    terminal).
-2. The uploader finds every completed run not yet uploaded, renames
-   `shield_data.csv` to `pressure_gauge_data.csv`, drops the `backup/`
-   directory, and opens one pull request per run against this repository
-   (branch `auto/run-<run_id>`, folder `run_data/YY.MM.DD_run_X_HHhMM/`).
-   Already-uploaded runs are skipped, so running it any time is safe.
+2. The uploader finds every completed run not yet uploaded, converts
+   `shield_data.csv` to a zstd-compressed `measurements.parquet` (verified
+   as an exact round-trip), drops the `backup/` directory, and opens one
+   pull request per run against this repository (branch `auto/run-<run_id>`,
+   folder `run_data/YY.MM.DD_run_X_HHhMM/`). Already-uploaded runs are
+   skipped, so running it any time is safe.
 3. Review and merge the PR once CI validation passes.
 4. After merge, CI rebuilds the database and updates the
    [`data-latest` release](https://github.com/PTTEPxMIT/SHIELD-Data/releases/tag/data-latest);
@@ -188,7 +189,9 @@ One-time setup (GitHub token + config) is documented in
 For runs coming from anywhere else:
 
 1. Copy the run folder to `run_data/YY.MM.DD_run_X_HHhMM/` containing
-   `pressure_gauge_data.csv` and `run_metadata.json` (no `backup/` directory)
+   `measurements.parquet` and `run_metadata.json` (no `backup/` directory) —
+   convert a CSV with
+   `python -m shield_data.store convert <run_folder> --delete-csv`
 2. Commit the run folder and submit a PR (see [CONTRIBUTING.md](CONTRIBUTING.md))
 3. After merge, CI rebuilds the database and updates the `data-latest` release
 


### PR DESCRIPTION
Documents how run data actually gets here. The README's "Adding New Data" section now has two subsections:

- **Uploading from the rig (normal path)**: double-click `upload_runs.bat` (or run `shield-das-upload`) on the rig PC after a run finishes — one PR per completed run, idempotent, links to the SHIELD_DAS setup doc. Companion PR: PTTEPxMIT/SHIELD_DAS#71.
- **Adding a run manually**: the existing copy-folder-and-PR path, now with the expected folder contents spelled out.

Docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)