### PR TITLE
Per-run Parquet storage with a downloadable catalogue

### DIFF
--- a/.github/workflows/build_db_release.yml
+++ b/.github/workflows/build_db_release.yml
@@ -1,9 +1,10 @@
 name: Build Database Release
 
-# Rebuilds shield_data.db from run_data/ whenever data lands on main, and
-# attaches it (gzipped, with a checksum manifest) to the rolling `data-latest`
-# GitHub release. The shield_data package downloads and caches that release on
-# first use — the database is never committed to git.
+# Rebuilds the run catalogue (and, during the deprecation window, the legacy
+# shield_data.db) from run_data/ whenever data lands on main, and attaches
+# them with a checksum manifest to the rolling `data-latest` GitHub release.
+# The shield_data package downloads and caches the catalogue on first use;
+# individual runs are fetched per-file from the repository's raw URLs.
 
 on:
   push:
@@ -11,6 +12,7 @@ on:
     paths:
       - 'run_data/**'
       - 'src/shield_data/build_db.py'
+      - 'src/shield_data/store.py'
   workflow_dispatch:
 
 permissions:
@@ -31,10 +33,13 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install dependencies
-        run: pip install pandas
+      - name: Install package
+        run: pip install -e .
 
-      - name: Build database
+      - name: Build catalogue
+        run: python -m shield_data.store catalogue run_data --output catalogue.parquet
+
+      - name: Build legacy database
         run: python src/shield_data/build_db.py --data-dir run_data --output shield_data.db
 
       - name: Compress and generate manifest
@@ -52,6 +57,9 @@ jobs:
           with gzip.open("shield_data.db.gz", "wb", compresslevel=9) as f:
               f.write(raw)
 
+          cat_raw = open("catalogue.parquet", "rb").read()
+          cat_sha = hashlib.sha256(cat_raw).hexdigest()
+
           conn = sqlite3.connect("shield_data.db")
           runs = conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0]
           measurements = conn.execute("SELECT COUNT(*) FROM measurements").fetchone()[0]
@@ -59,6 +67,8 @@ jobs:
 
           manifest = {
               "sha256": sha,
+              "catalogue_sha256": cat_sha,
+              "catalogue_size_bytes": len(cat_raw),
               "runs": runs,
               "measurements": measurements,
               "size_bytes": len(raw),
@@ -78,7 +88,7 @@ jobs:
             gh release create data-latest \
               --repo "$GITHUB_REPOSITORY" \
               --title "SHIELD data (latest)" \
-              --notes "Rolling release: the latest shield_data.db built from run_data on main. Updated automatically by CI — do not edit by hand." \
+              --notes "Rolling release: the run catalogue (and legacy shield_data.db) built from run_data on main. Updated automatically by CI — do not edit by hand." \
               --latest=false
-          gh release upload data-latest shield_data.db.gz manifest.json \
+          gh release upload data-latest catalogue.parquet shield_data.db.gz manifest.json \
             --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/validate_data.yml
+++ b/.github/workflows/validate_data.yml
@@ -68,8 +68,8 @@ jobs:
       
       - name: Install dependencies
         run: |
-          pip install pandas
-      
+          pip install pandas pyarrow
+
       - name: Create validation script
         run: |
           cat > validate_structure.py << 'SCRIPT'
@@ -77,29 +77,39 @@ jobs:
           import json
           import pandas as pd
           from pathlib import Path
-          
+
           def validate_run(folder):
               errors = []
               folder_path = Path(folder)
-              
+
               print(f"\nChecking: {folder}")
-              
-              # Check CSV
+
+              # Check measurements: measurements.parquet is the current format;
+              # pressure_gauge_data.csv is the legacy one (still accepted).
+              parquet_path = folder_path / "measurements.parquet"
               csv_path = folder_path / "pressure_gauge_data.csv"
-              if not csv_path.exists():
-                  errors.append(f"Missing: {csv_path}")
+              if parquet_path.exists() and csv_path.exists():
+                  errors.append("Both measurements.parquet and pressure_gauge_data.csv present — keep one")
+              elif not parquet_path.exists() and not csv_path.exists():
+                  errors.append("Missing measurements.parquet (or legacy pressure_gauge_data.csv)")
               else:
+                  data_path = parquet_path if parquet_path.exists() else csv_path
                   try:
-                      df = pd.read_csv(csv_path)
-                      required_cols = ["RealTimestamp", "WGM701_Voltage (V)", "CVM211_Voltage (V)", 
-                                     "Baratron626D_1KT_Voltage (V)", "Baratron626D_1T_Voltage (V)"]
-                      missing = [col for col in required_cols if col not in df.columns]
-                      if missing:
-                          errors.append(f"CSV missing columns: {missing}")
+                      if data_path.suffix == ".parquet":
+                          df = pd.read_parquet(data_path)
                       else:
-                          print(f"  ✓ CSV valid ({len(df)} rows)")
+                          df = pd.read_csv(data_path)
+                      if "RealTimestamp" not in df.columns:
+                          errors.append("Data file missing RealTimestamp column")
+                      channels = [c for c in df.columns if c != "RealTimestamp"]
+                      if not channels:
+                          errors.append("Data file has no data channels")
+                      if len(df) == 0:
+                          errors.append("Data file has no rows")
+                      if not errors:
+                          print(f"  ✓ {data_path.name} valid ({len(df)} rows, channels: {channels})")
                   except Exception as e:
-                      errors.append(f"CSV error: {e}")
+                      errors.append(f"Data file error: {e}")
               
               # Check JSON
               json_path = folder_path / "run_metadata.json"
@@ -196,8 +206,8 @@ jobs:
           python-version: '3.11'
       
       - name: Install dependencies
-        run: pip install pandas
-      
+        run: pip install pandas pyarrow
+
       - name: Generate PR summary
         id: summary
         run: |
@@ -228,24 +238,26 @@ jobs:
                   continue
                   
               json_path = folder_path / "run_metadata.json"
+              parquet_path = folder_path / "measurements.parquet"
               csv_path = folder_path / "pressure_gauge_data.csv"
-              
+
               run_id = folder_path.name
-              
+
               if json_path.exists():
                   with open(json_path) as f:
                       metadata = json.load(f)
                   run_info = metadata.get("run_info", {})
               else:
                   run_info = {}
-              
+
               measurement_count = 0
-              if csv_path.exists():
-                  try:
-                      df = pd.read_csv(csv_path)
-                      measurement_count = len(df)
-                  except:
-                      pass
+              try:
+                  if parquet_path.exists():
+                      measurement_count = len(pd.read_parquet(parquet_path))
+                  elif csv_path.exists():
+                      measurement_count = len(pd.read_csv(csv_path))
+              except:
+                  pass
               
               runs_info.append({
                   "run_id": run_id,

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ A Python package providing experimental permeation data from the SHIELD hydrogen
 
 ## Overview
 
-SHIELD-Data bundles experimental data in an SQLite database for easy access and analysis. The package includes:
+SHIELD-Data stores each experimental run as a compressed Parquet file and serves runs individually — you download only the runs you ask for, not the whole dataset. The package includes:
 
-- **826,000+ measurements** from 8 experimental runs
-- **SQLite database** for efficient querying and filtering
-- **Simple API** for loading data and metadata
-- **Bundled with pip install** - no external data downloads needed
+- **4.2M+ measurements** from 105+ experimental runs
+- **Per-run Parquet storage**: every channel the rig recorded (gauge voltages, temperatures, future instruments), ~10x smaller than CSV, no schema migrations when instrumentation changes
+- **A small catalogue** (~1 MB) for browsing and filtering runs by material, coating, furnace setpoint, recorded channels, ...
+- **Simple API**: filter the catalogue, then `load()` fetches, verifies, and caches just those runs
 
 ## Installation
 
@@ -49,17 +49,22 @@ Load the catalogue of all experimental runs.
 ```python
 cat = sd.catalogue()
 # Returns DataFrame with columns:
-#   run_id, date, start_time, run_type, furnace_setpoint, material, coating
+#   run_id, date, start_time, end_time, run_type, furnace_setpoint,
+#   material, coating, channels, n_measurements, data_file, size_bytes,
+#   sha256, metadata
 ```
 
 ### `load(run_id)`
-Load pressure gauge data for a specific run.
+Load the measurements of a specific run. Only that run's file is downloaded
+(verified against the catalogue checksum and cached locally).
 
 ```python
 df = sd.load("25.10.06_run_1_10h41")
-# Returns DataFrame with columns:
-#   timestamp, WGM701_voltage, CVM211_voltage,
-#   Baratron626D_1KT_voltage, Baratron626D_1T_voltage, run_id
+# Returns the channels exactly as the rig recorded them, e.g.:
+#   RealTimestamp (datetime64), WGM701_Voltage (V), CVM211_Voltage (V),
+#   Baratron626D_1KT_Voltage (V), Baratron626D_1T_Voltage (V),
+#   Local_temperature (C), furnace_thermocouple_Voltage (mV), run_id
+# Older runs recorded fewer channels — check catalogue()["channels"].
 ```
 
 ### `load_metadata(run_id)`
@@ -106,28 +111,27 @@ plt.show()
 
 ## Data Structure
 
-### Database Schema
+### Storage Format
 
-The SQLite database contains two tables:
+Each run folder holds two files:
 
-**runs table:**
-- `run_id` (TEXT, PRIMARY KEY)
-- `date` (TEXT)
-- `start_time` (TEXT)
-- `run_type` (TEXT)
-- `furnace_setpoint` (INTEGER)
-- `material` (TEXT, nullable)
-- `coating` (TEXT, nullable)
-- `metadata` (TEXT, JSON)
+- `measurements.parquet` — every channel the rig recorded, zstd-compressed.
+  Parquet files are self-describing: column names and types are embedded, so
+  runs with different instrumentation coexist without any schema migration.
+- `run_metadata.json` — run info, gauge and thermocouple configuration.
 
-**measurements table:**
-- `id` (INTEGER, PRIMARY KEY)
-- `run_id` (TEXT, FOREIGN KEY)
-- `timestamp` (TEXT)
-- `WGM701_voltage` (REAL)
-- `CVM211_voltage` (REAL)
-- `Baratron626D_1KT_voltage` (REAL)
-- `Baratron626D_1T_voltage` (REAL)
+The catalogue (built by CI, attached to the
+[`data-latest` release](https://github.com/PTTEPxMIT/SHIELD-Data/releases/tag/data-latest))
+has one row per run: normalised metadata fields, the list of recorded
+`channels`, measurement counts, and each data file's sha256 (used to verify
+per-run downloads). Refresh it with `shield_data.update_catalogue()`.
+
+**Legacy SQLite database** (deprecated): the monolithic `shield_data.db` is
+still built and released while downstream consumers migrate. Pinning it via
+the `SHIELD_DATA_DB` environment variable preserves the old behaviour,
+including the old `timestamp` / `*_voltage` column names. Note it carries
+only the four original gauge-voltage columns — temperature channels are only
+available through the Parquet path.
 
 ### Run Metadata
 
@@ -143,20 +147,19 @@ Each run includes detailed metadata:
 SHIELD-Data/
 ├── run_data/                     # Raw data (not in package)
 │   ├── YY.MM.DD_run_X_HHhMM/    # Individual run folders
-│   │   ├── pressure_gauge_data.csv
+│   │   ├── measurements.parquet
 │   │   └── run_metadata.json
 │   └── ...
 ├── src/shield_data/
 │   ├── db.py                     # Main API
-│   └── build_db.py               # Database builder
+│   ├── store.py                  # Parquet storage layer + catalogue builder
+│   └── build_db.py               # Legacy database builder (deprecated)
 └── test/                         # Unit tests
 ```
 
-The SQLite database itself is not stored in git: CI builds it from `run_data/`
-and publishes it to the [`data-latest` release](https://github.com/PTTEPxMIT/SHIELD-Data/releases/tag/data-latest).
-The package downloads and caches it on first use; refresh with
-`shield_data.update_database()`, or pin a local file via the `SHIELD_DATA_DB`
-environment variable.
+In a repo checkout, the API reads `run_data/` directly. Installed packages
+fetch the catalogue from the `data-latest` release and individual runs from
+the repository's raw URLs, caching everything per-user.
 
 ## Contributing
 
@@ -172,18 +175,17 @@ When adding new experimental runs:
 
 ### Development
 
-To rebuild the database from raw data:
+To convert a legacy CSV run and rebuild the catalogue locally:
 
-```python
-from shield_data.build_db import build_database
-
-build_database("run_data")  # Creates src/shield_data/shield_data.db
+```bash
+python -m shield_data.store convert run_data/YY.MM.DD_run_X_HHhMM --delete-csv
+python -m shield_data.store catalogue run_data --output catalogue.parquet
 ```
 
 ## Requirements
 
 - Python >= 3.9
-- pandas
+- pandas, pyarrow
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ description = "A database for results collected from the SHIELD permeation rig"
 readme = "README.md"
 requires-python = ">=3.9"
 license = { file = "LICENSE" }
-dependencies = ["pandas"]
+dependencies = ["pandas", "pyarrow"]
 classifiers = [
     "Natural Language :: English",
     "Topic :: Scientific/Engineering",

--- a/src/shield_data/__init__.py
+++ b/src/shield_data/__init__.py
@@ -11,6 +11,7 @@ from shield_data.db import (
     load,
     load_filtered,
     load_metadata,
+    update_catalogue,
     update_database,
 )
 
@@ -20,5 +21,6 @@ __all__ = [
     "load",
     "load_filtered",
     "load_metadata",
+    "update_catalogue",
     "update_database",
 ]

--- a/src/shield_data/build_db.py
+++ b/src/shield_data/build_db.py
@@ -1,4 +1,11 @@
-"""Build SQLite database from run_data folder."""
+"""Build the legacy SQLite database from the run_data folder.
+
+Deprecated: runs are now stored and served as per-run Parquet files (see
+shield_data.store). This builder is kept while downstream consumers migrate
+off the monolithic database; it reads either storage format. Note the
+measurements table keeps only the four original gauge-voltage columns —
+additional channels (e.g. temperatures) are available via the Parquet path.
+"""
 
 import argparse
 import json
@@ -6,6 +13,8 @@ import sqlite3
 from pathlib import Path
 
 import pandas as pd
+
+from shield_data import store
 
 # CSV columns (with units, as written by SHIELD_DAS) in measurement-table order.
 _MEASUREMENT_CSV_COLUMNS = [
@@ -72,7 +81,6 @@ def _insert_run(cursor: sqlite3.Cursor, run_folder: Path) -> int:
     """
     run_id = run_folder.name
     metadata_file = run_folder / "run_metadata.json"
-    data_file = run_folder / "pressure_gauge_data.csv"
 
     with open(metadata_file) as f:
         metadata = json.load(f)
@@ -101,7 +109,16 @@ def _insert_run(cursor: sqlite3.Cursor, run_folder: Path) -> int:
         ),
     )
 
-    df = pd.read_csv(data_file)
+    csv_file = run_folder / store.LEGACY_CSV_FILENAME
+    if csv_file.exists():
+        df = pd.read_csv(csv_file)
+    else:
+        df = store.read_measurements(run_folder)
+        # The measurements table stores timestamps as text in the format the
+        # rig originally wrote (millisecond precision).
+        df[store.TIMESTAMP_COLUMN] = (
+            df[store.TIMESTAMP_COLUMN].dt.strftime("%Y-%m-%d %H:%M:%S.%f").str[:-3]
+        )
     columns = [
         df[name].where(pd.notna(df[name]), None)
         if name in df.columns

--- a/src/shield_data/db.py
+++ b/src/shield_data/db.py
@@ -1,18 +1,26 @@
-"""SQLite database access for SHIELD experimental data.
+"""Access to SHIELD experimental runs: per-run Parquet with a small catalogue.
 
-The database itself is a build artifact. It is no longer committed to git or
-shipped inside the package: CI rebuilds it whenever run data lands on main and
-attaches it (gzipped, with a checksum manifest) to the rolling ``data-latest``
-GitHub release. On first use this module downloads and caches that release;
-call :func:`update_database` to pick up newly published runs.
+Runs are stored one Parquet file per run under ``run_data/`` in the git repo
+(see :mod:`shield_data.store`). Consumers no longer download the whole
+dataset: :func:`catalogue` reads a small catalogue file (built by CI and
+attached to the rolling ``data-latest`` release), and :func:`load` fetches
+just the requested run from the repository, verifies its sha256 against the
+catalogue, and caches it in a per-user cache directory.
 
-Resolution order for the database path:
+Resolution order in this default "store" mode:
 
-1. The ``SHIELD_DATA_DB`` environment variable (offline use, reproducible
-   pipelines, or a custom build).
-2. ``shield_data.db`` next to this file (a repo checkout where
-   ``build_db.py`` has been run).
-3. The cached download of the ``data-latest`` release (fetched on first use).
+1. A repo checkout: if ``run_data/`` exists next to the package source, runs
+   are read straight from disk and the catalogue is built on the fly.
+2. The per-user cache of previously fetched runs and catalogue.
+3. Download: the catalogue from the ``data-latest`` release
+   (:func:`update_catalogue` refreshes it), individual runs from the
+   repository's raw URLs.
+
+Legacy mode: pinning a database via the ``SHIELD_DATA_DB`` environment
+variable (or the ``DB_PATH`` module attribute) preserves the original SQLite
+behaviour exactly — including the old ``timestamp`` / ``*_voltage`` column
+names — for reproducible pipelines that predate per-run storage. This path
+is deprecated and will be removed once downstream consumers migrate.
 """
 
 import gzip
@@ -21,31 +29,48 @@ import json
 import os
 import platform
 import sqlite3
+import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
 
-# Environment variable that pins the database to a local file.
-DB_ENV_VAR = "SHIELD_DATA_DB"
+from shield_data import store
 
-# Rolling GitHub release that CI attaches the latest built database to.
+# Environment variables pinning local files (legacy DB pin enables legacy mode).
+DB_ENV_VAR = "SHIELD_DATA_DB"
+CATALOGUE_ENV_VAR = "SHIELD_DATA_CATALOGUE"
+
+# Rolling GitHub release that CI attaches the catalogue (and, during the
+# deprecation window, the legacy database) to.
 DATA_RELEASE_URL = (
     "https://github.com/PTTEPxMIT/SHIELD-Data/releases/download/data-latest"
 )
 
-# Database sitting next to the source in a repo checkout (never present in an
-# installed package).
-_LOCAL_DB = Path(__file__).parent / "shield_data.db"
+# Individual runs are fetched per-file from the repository itself.
+RAW_DATA_URL = "https://raw.githubusercontent.com/PTTEPxMIT/SHIELD-Data/main/run_data"
 
-# Explicit override; tests monkeypatch this. None means "resolve on first use"
-# via get_db_path().
+# Repo-checkout locations (never present in an installed package).
+_LOCAL_DB = Path(__file__).parent / "shield_data.db"
+_REPO_RUN_DATA = Path(__file__).parents[2] / "run_data"
+
+# Explicit overrides; tests monkeypatch these. None means "resolve on use".
 DB_PATH: Path | None = None
+RUN_DATA_DIR: Path | None = None
+CATALOGUE_PATH: Path | None = None
+
+# Per-process memo of catalogues built from a local run_data checkout.
+_CATALOGUE_MEMO: dict[str, pd.DataFrame] = {}
+
+
+def _legacy_mode() -> bool:
+    """True when a SQLite database is explicitly pinned (legacy behaviour)."""
+    return DB_PATH is not None or bool(os.environ.get(DB_ENV_VAR))
 
 
 def _cache_dir() -> Path:
-    """Per-user cache directory for the downloaded database."""
+    """Per-user cache directory for downloaded runs and catalogue."""
     if os.name == "nt":
         base = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
     elif platform.system() == "Darwin":
@@ -60,13 +85,130 @@ def _fetch(url: str) -> bytes:
         return response.read()
 
 
-def update_database() -> Path:
-    """Download the latest released database into the local cache.
+def update_catalogue() -> Path:
+    """Download the latest released catalogue into the local cache.
 
     Fetches ``manifest.json`` from the ``data-latest`` GitHub release and
-    downloads the gzipped database if the cached copy is missing or outdated.
-    The SHA-256 checksum is verified before the cache is replaced, and the
-    cached copy is left untouched if anything fails.
+    downloads ``catalogue.parquet`` if the cached copy is missing or
+    outdated. The sha256 is verified before the cache is replaced.
+
+    Returns:
+        Path to the cached catalogue file
+    """
+    cache = _cache_dir()
+    cache.mkdir(parents=True, exist_ok=True)
+    cat_file = cache / store.CATALOGUE_FILENAME
+    manifest_file = cache / "catalogue_manifest.json"
+
+    manifest = json.loads(_fetch(f"{DATA_RELEASE_URL}/manifest.json"))
+    expected_sha = manifest.get("catalogue_sha256")
+    if not expected_sha:
+        raise RuntimeError(
+            "The data-latest release does not include a catalogue yet; "
+            "use update_database() until one is published."
+        )
+
+    if cat_file.exists() and manifest_file.exists():
+        cached = json.loads(manifest_file.read_text())
+        if cached.get("catalogue_sha256") == expected_sha:
+            return cat_file
+
+    raw = _fetch(f"{DATA_RELEASE_URL}/{store.CATALOGUE_FILENAME}")
+    actual_sha = hashlib.sha256(raw).hexdigest()
+    if actual_sha != expected_sha:
+        raise RuntimeError(
+            f"Downloaded catalogue checksum mismatch: {actual_sha} != {expected_sha}"
+        )
+
+    tmp = cat_file.with_suffix(".tmp")
+    tmp.write_bytes(raw)
+    tmp.replace(cat_file)
+    manifest_file.write_text(json.dumps(manifest))
+    print(f"✓ shield_data: cached catalogue ({manifest.get('runs', '?')} runs)")
+    return cat_file
+
+
+def _run_data_dir() -> Path | None:
+    """Local run_data checkout, if there is one."""
+    d = RUN_DATA_DIR if RUN_DATA_DIR is not None else _REPO_RUN_DATA
+    return d if d.is_dir() else None
+
+
+def _store_catalogue() -> pd.DataFrame | None:
+    """The catalogue in store mode: local checkout, pin, cache, or download."""
+    data_dir = _run_data_dir()
+    if data_dir is not None:
+        key = str(data_dir.resolve())
+        if key not in _CATALOGUE_MEMO:
+            _CATALOGUE_MEMO[key] = store.build_catalogue(data_dir)
+        return _CATALOGUE_MEMO[key].copy()
+
+    pin = os.environ.get(CATALOGUE_ENV_VAR) or CATALOGUE_PATH
+    if pin:
+        path = Path(pin)
+        if not path.exists():
+            raise FileNotFoundError(f"Pinned catalogue is missing: {path}")
+        return pd.read_parquet(path)
+
+    cached = _cache_dir() / store.CATALOGUE_FILENAME
+    if cached.exists():
+        return pd.read_parquet(cached)
+
+    try:
+        return pd.read_parquet(update_catalogue())
+    except (urllib.error.URLError, RuntimeError, OSError):
+        return None
+
+
+def _ensure_cached_run(run_id: str) -> Path:
+    """Return the run's cached data file, downloading it if necessary."""
+    run_cache = _cache_dir() / "runs" / run_id
+    for name in (store.MEASUREMENTS_FILENAME, store.LEGACY_CSV_FILENAME):
+        if (run_cache / name).exists():
+            return run_cache / name
+
+    cat = _store_catalogue()
+    expected_sha = None
+    candidates = [store.MEASUREMENTS_FILENAME, store.LEGACY_CSV_FILENAME]
+    if cat is not None:
+        row = cat[cat["run_id"] == run_id]
+        if not row.empty:
+            candidates = [row.iloc[0]["data_file"]]
+            expected_sha = row.iloc[0]["sha256"]
+
+    for name in candidates:
+        try:
+            raw = _fetch(f"{RAW_DATA_URL}/{run_id}/{name}")
+        except urllib.error.HTTPError as err:
+            if err.code == 404:
+                continue
+            raise
+        if expected_sha and hashlib.sha256(raw).hexdigest() != expected_sha:
+            raise RuntimeError(
+                f"Downloaded {run_id}/{name} does not match the catalogue "
+                "checksum. The catalogue may be stale: run "
+                "shield_data.update_catalogue() and retry."
+            )
+        run_cache.mkdir(parents=True, exist_ok=True)
+        tmp = run_cache / (name + ".tmp")
+        tmp.write_bytes(raw)
+        tmp.replace(run_cache / name)
+        return run_cache / name
+
+    raise FileNotFoundError(
+        f"Run {run_id!r} was not found locally, in the cache, or at "
+        f"{RAW_DATA_URL}/{run_id}/"
+    )
+
+
+# --- legacy SQLite path (active only when a database is pinned) -------------
+
+
+def update_database() -> Path:
+    """Download the latest released legacy database into the local cache.
+
+    Deprecated: per-run Parquet access via :func:`load` needs no database.
+    Kept while downstream consumers migrate.
 
     Returns:
         Path to the cached database file
@@ -103,7 +245,7 @@ def update_database() -> Path:
 
 
 def get_db_path() -> Path:
-    """Resolve the database path (see module docstring for the order)."""
+    """Resolve the legacy database path (env pin, checkout, cache, download)."""
     env = os.environ.get(DB_ENV_VAR)
     if env:
         path = Path(env)
@@ -119,32 +261,61 @@ def get_db_path() -> Path:
 
 
 def _get_connection() -> sqlite3.Connection:
-    """Get database connection with row factory."""
+    """Get legacy database connection with row factory."""
     conn = sqlite3.connect(DB_PATH or get_db_path())
     conn.row_factory = sqlite3.Row
     return conn
 
 
+# --- public API -------------------------------------------------------------
+
+
 def catalogue() -> pd.DataFrame:
-    """Load catalogue of all experimental runs.
+    """Load the catalogue of all experimental runs.
+
+    In store mode the catalogue has one row per run with normalised metadata
+    fields (date, start_time, end_time, run_type, furnace_setpoint, material,
+    coating), the list of recorded ``channels``, ``n_measurements``, and the
+    data file's checksum. With a pinned database (legacy mode) it is the old
+    SQLite ``runs`` table.
 
     Returns:
-        DataFrame with run metadata (run_id, date, run_type,
-        furnace_setpoint, etc.)
+        DataFrame with one row per run
     """
+    if not _legacy_mode():
+        cat = _store_catalogue()
+        if cat is not None:
+            return cat
     with _get_connection() as conn:
         return pd.read_sql_query("SELECT * FROM runs", conn)
 
 
 def load(run_id: str) -> pd.DataFrame:
-    """Load pressure gauge data for a specific run.
+    """Load the measurements of a specific run.
+
+    Store mode returns the channels exactly as the rig recorded them —
+    ``RealTimestamp`` (datetime64) plus every recorded column, e.g.
+    ``WGM701_Voltage (V)`` or ``Local_temperature (C)`` — with a ``run_id``
+    column appended. Only this run's file is downloaded (and cached); the
+    download is verified against the catalogue's sha256.
+
+    Legacy mode (pinned database) keeps the old ``timestamp`` /
+    ``*_voltage`` columns.
 
     Args:
         run_id: The run ID (e.g., "25.10.06_run_1_10h41")
 
     Returns:
-        DataFrame with timestamp and gauge voltage measurements
+        DataFrame with one row per measurement
     """
+    if not _legacy_mode():
+        data_dir = _run_data_dir()
+        if data_dir is not None and (data_dir / run_id).is_dir():
+            df = store.read_measurements(data_dir / run_id)
+        else:
+            df = store.read_measurements(_ensure_cached_run(run_id).parent)
+        df["run_id"] = run_id
+        return df
     with _get_connection() as conn:
         return pd.read_sql_query(
             "SELECT * FROM measurements WHERE run_id = ?", conn, params=(run_id,)
@@ -160,6 +331,13 @@ def load_metadata(run_id: str) -> dict[str, Any]:
     Returns:
         Dictionary with run_info, gauges, and thermocouples
     """
+    if not _legacy_mode():
+        cat = _store_catalogue()
+        if cat is not None:
+            row = cat[cat["run_id"] == run_id]
+            if row.empty:
+                raise KeyError(f"Run {run_id!r} is not in the catalogue")
+            return json.loads(row.iloc[0]["metadata"])
     with _get_connection() as conn:
         row = conn.execute(
             "SELECT metadata FROM runs WHERE run_id = ?", (run_id,)
@@ -169,6 +347,11 @@ def load_metadata(run_id: str) -> dict[str, Any]:
 
 def load_filtered(**filters) -> pd.DataFrame:
     """Load data for runs matching filter criteria.
+
+    Filters apply to catalogue columns, so any normalised metadata field
+    works (material, coating, furnace_setpoint, run_type, date, ...). In
+    store mode only the matching runs are downloaded; columns are aligned
+    across runs, with NaN where a run did not record a channel.
 
     Args:
         **filters: Column filters (e.g., run_type="permeation_exp",
@@ -191,6 +374,9 @@ def load_filtered(**filters) -> pd.DataFrame:
 
     if cat.empty:
         return pd.DataFrame()
+
+    if not _legacy_mode():
+        return pd.concat([load(run_id) for run_id in cat["run_id"]], ignore_index=True)
 
     # Load all matching runs
     with _get_connection() as conn:

--- a/src/shield_data/store.py
+++ b/src/shield_data/store.py
@@ -1,0 +1,275 @@
+"""Run-folder storage layer: Parquet measurements and the run catalogue.
+
+Each run folder under ``run_data/`` stores its measurements as a single
+zstd-compressed Parquet file (``measurements.parquet``) alongside
+``run_metadata.json``. Parquet files are self-describing: a run keeps exactly
+the columns the rig recorded (four gauge voltages, optionally temperatures,
+or whatever future instrumentation adds), so new channels never require a
+schema migration. Legacy runs that still hold a ``pressure_gauge_data.csv``
+are read transparently.
+
+This module provides:
+
+- :func:`read_measurements` — read a run folder in either format, with
+  ``RealTimestamp`` parsed to datetimes.
+- :func:`convert_run` — convert a legacy CSV run to Parquet, verifying an
+  exact round-trip (row counts, column names, bit-identical values) before
+  optionally deleting the CSV.
+- :func:`build_catalogue` — scan ``run_data/`` into the catalogue: one row
+  per run with normalised metadata fields, the list of recorded channels,
+  and the sha256 of the data file (used to verify per-run downloads).
+
+CLI (used by CI and for the one-off backfill)::
+
+    python -m shield_data.store convert run_data --delete-csv
+    python -m shield_data.store catalogue run_data --output catalogue.parquet
+"""
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+MEASUREMENTS_FILENAME = "measurements.parquet"
+LEGACY_CSV_FILENAME = "pressure_gauge_data.csv"
+CATALOGUE_FILENAME = "catalogue.parquet"
+METADATA_FILENAME = "run_metadata.json"
+TIMESTAMP_COLUMN = "RealTimestamp"
+
+PARQUET_COMPRESSION = "zstd"
+PARQUET_COMPRESSION_LEVEL = 9
+
+
+def data_file(run_dir: str | Path) -> Path:
+    """Return the run's data file (Parquet preferred, legacy CSV fallback).
+
+    Args:
+        run_dir: Run folder (run_data/YY.MM.DD_run_X_HHhMM)
+
+    Raises:
+        FileNotFoundError: If the folder holds neither format.
+    """
+    run_dir = Path(run_dir)
+    parquet = run_dir / MEASUREMENTS_FILENAME
+    if parquet.exists():
+        return parquet
+    csv = run_dir / LEGACY_CSV_FILENAME
+    if csv.exists():
+        return csv
+    raise FileNotFoundError(
+        f"{run_dir} contains neither {MEASUREMENTS_FILENAME} nor {LEGACY_CSV_FILENAME}"
+    )
+
+
+def _parse_timestamps(df: pd.DataFrame) -> pd.DataFrame:
+    if TIMESTAMP_COLUMN in df.columns and not pd.api.types.is_datetime64_any_dtype(
+        df[TIMESTAMP_COLUMN]
+    ):
+        df[TIMESTAMP_COLUMN] = pd.to_datetime(df[TIMESTAMP_COLUMN], format="mixed")
+    return df
+
+
+def read_measurements(run_dir: str | Path) -> pd.DataFrame:
+    """Read a run's measurements from either storage format.
+
+    Args:
+        run_dir: Run folder containing measurements.parquet or the legacy
+            pressure_gauge_data.csv
+
+    Returns:
+        DataFrame with RealTimestamp as datetime64 and every channel the rig
+        recorded (voltages in V or mV, temperatures in C — see column names)
+    """
+    path = data_file(run_dir)
+    if path.suffix == ".parquet":
+        return pd.read_parquet(path)
+    return _parse_timestamps(pd.read_csv(path))
+
+
+def channels(df: pd.DataFrame) -> list[str]:
+    """Names of the recorded data channels (every column except the timestamp)."""
+    return [c for c in df.columns if c != TIMESTAMP_COLUMN]
+
+
+def sha256_of(path: str | Path) -> str:
+    """sha256 hex digest of a file's bytes."""
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _verify_round_trip(original: pd.DataFrame, parquet_path: Path) -> list[str]:
+    """Compare a written Parquet file against the DataFrame it came from.
+
+    Returns a list of problems; empty means the round-trip is exact.
+    """
+    problems = []
+    back = pd.read_parquet(parquet_path)
+    if len(back) != len(original):
+        problems.append(f"row count {len(back)} != {len(original)}")
+    if list(back.columns) != list(original.columns):
+        problems.append(f"columns {list(back.columns)} != {list(original.columns)}")
+        return problems
+    for col in original.columns:
+        a, b = original[col], back[col]
+        if col == TIMESTAMP_COLUMN:
+            if not a.equals(b.astype(a.dtype)):
+                problems.append(f"timestamp mismatch in {col}")
+        elif not a.equals(b):
+            problems.append(f"value mismatch in {col}")
+    return problems
+
+
+def convert_run(run_dir: str | Path, delete_csv: bool = False) -> Path:
+    """Convert one legacy CSV run folder to Parquet, verifying exactness.
+
+    The CSV is read, timestamps parsed, and the result written as
+    zstd-compressed Parquet. The written file is read back and checked for an
+    exact round-trip (same rows, same columns, bit-identical float64 values)
+    before the CSV is optionally deleted — a failed check raises and leaves
+    the CSV in place.
+
+    Args:
+        run_dir: Run folder containing pressure_gauge_data.csv
+        delete_csv: Remove the CSV after a verified conversion
+
+    Returns:
+        Path to the written measurements.parquet
+
+    Raises:
+        RuntimeError: If the round-trip verification fails.
+    """
+    run_dir = Path(run_dir)
+    csv_path = run_dir / LEGACY_CSV_FILENAME
+    df = _parse_timestamps(pd.read_csv(csv_path))
+
+    parquet_path = run_dir / MEASUREMENTS_FILENAME
+    df.to_parquet(
+        parquet_path,
+        index=False,
+        compression=PARQUET_COMPRESSION,
+        compression_level=PARQUET_COMPRESSION_LEVEL,
+    )
+
+    problems = _verify_round_trip(df, parquet_path)
+    if problems:
+        parquet_path.unlink(missing_ok=True)
+        raise RuntimeError(f"{run_dir.name}: round-trip failed: {'; '.join(problems)}")
+
+    if delete_csv:
+        csv_path.unlink()
+    return parquet_path
+
+
+def _normalised_run_fields(metadata: dict) -> dict:
+    run_info = metadata.get("run_info", {})
+    return {
+        "date": run_info.get("date"),
+        "start_time": run_info.get("start_time"),
+        "end_time": run_info.get("end_time"),
+        "run_type": run_info.get("run_type"),
+        "furnace_setpoint": run_info.get("furnace_setpoint"),
+        # v1.0 metadata calls this "material", v1.3 "sample_material"
+        "material": run_info.get("material", run_info.get("sample_material")),
+        "coating": run_info.get("coating"),
+    }
+
+
+def build_catalogue(
+    data_dir: str | Path, output: str | Path | None = None
+) -> pd.DataFrame:
+    """Build the run catalogue from a run_data directory.
+
+    One row per run folder: run_id, normalised metadata fields (material
+    falls back to v1.3's sample_material), the list of recorded channels,
+    measurement count, and the data file's name, size, and sha256 (used to
+    verify per-run downloads). The full run_metadata.json is carried in the
+    ``metadata`` column so ``load_metadata`` needs no further download.
+
+    Args:
+        data_dir: Path to the run_data folder
+        output: Optional path to also write the catalogue as Parquet
+
+    Returns:
+        The catalogue as a DataFrame, sorted by run_id
+    """
+    data_dir = Path(data_dir)
+    rows = []
+    for run_dir in sorted(data_dir.iterdir()):
+        if not run_dir.is_dir() or run_dir.name.startswith("."):
+            continue
+        with open(run_dir / METADATA_FILENAME) as f:
+            metadata = json.load(f)
+        df = read_measurements(run_dir)
+        path = data_file(run_dir)
+        rows.append(
+            {
+                "run_id": run_dir.name,
+                **_normalised_run_fields(metadata),
+                "channels": channels(df),
+                "n_measurements": len(df),
+                "data_file": path.name,
+                "size_bytes": path.stat().st_size,
+                "sha256": sha256_of(path),
+                "metadata": json.dumps(metadata),
+            }
+        )
+
+    cat = pd.DataFrame(rows)
+    if output is not None:
+        cat.to_parquet(Path(output), index=False, compression=PARQUET_COMPRESSION)
+    return cat
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: convert legacy CSV runs to Parquet, or build the catalogue."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_convert = sub.add_parser("convert", help="convert CSV run folders to Parquet")
+    p_convert.add_argument("data_dir", help="run_data directory (or one run folder)")
+    p_convert.add_argument(
+        "--delete-csv",
+        action="store_true",
+        help="remove each CSV after its conversion is verified",
+    )
+
+    p_cat = sub.add_parser("catalogue", help="build the run catalogue")
+    p_cat.add_argument("data_dir", help="run_data directory")
+    p_cat.add_argument("--output", default=CATALOGUE_FILENAME, help="output path")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "convert":
+        root = Path(args.data_dir)
+        if (root / LEGACY_CSV_FILENAME).exists():
+            run_dirs = [root]
+        else:
+            run_dirs = sorted(
+                d
+                for d in root.iterdir()
+                if d.is_dir()
+                and not d.name.startswith(".")
+                and (d / LEGACY_CSV_FILENAME).exists()
+            )
+        for run_dir in run_dirs:
+            csv_size = (run_dir / LEGACY_CSV_FILENAME).stat().st_size
+            parquet_path = convert_run(run_dir, delete_csv=args.delete_csv)
+            print(
+                f"✓ {run_dir.name}: {csv_size / 1e6:.1f} MB csv -> "
+                f"{parquet_path.stat().st_size / 1e6:.1f} MB parquet"
+            )
+        print(f"Converted {len(run_dirs)} run(s)")
+    else:
+        cat = build_catalogue(args.data_dir, output=args.output)
+        print(f"✓ catalogue: {len(cat)} runs -> {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -63,6 +63,12 @@ def test_all_contains_load_metadata():
     assert "load_metadata" in shield_data.__all__
 
 
+def test_update_catalogue_is_exported():
+    """Test that update_catalogue function is exported."""
+    assert hasattr(shield_data, "update_catalogue")
+    assert "update_catalogue" in shield_data.__all__
+
+
 def test_all_has_correct_count():
-    """Test that __all__ contains exactly 6 items."""
-    assert len(shield_data.__all__) == 6
+    """Test that __all__ contains exactly 7 items."""
+    assert len(shield_data.__all__) == 7

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -7,8 +7,6 @@ Tests cover:
 """
 
 import json
-import subprocess
-import sys
 
 import pandas as pd
 import pytest

--- a/test/test_store.py
+++ b/test/test_store.py
@@ -1,0 +1,348 @@
+"""Unit tests for store.py and the store-mode (per-run Parquet) API in db.py.
+
+Tests cover:
+- CSV -> Parquet conversion with exact round-trip verification
+- Reading run folders in either storage format
+- Catalogue building (normalised fields, channels, checksums)
+- Store-mode catalogue/load/load_metadata/load_filtered
+- Per-run download, checksum verification, and caching
+"""
+
+import hashlib
+import json
+import urllib.error
+
+import pandas as pd
+import pytest
+
+from shield_data import db, store
+
+GAUGE_COLUMNS = [
+    "WGM701_Voltage (V)",
+    "CVM211_Voltage (V)",
+    "Baratron626D_1KT_Voltage (V)",
+    "Baratron626D_1T_Voltage (V)",
+]
+
+
+def _write_run(
+    data_dir,
+    run_id,
+    n_rows=3,
+    with_temperature=False,
+    material_key="material",
+    material="steel",
+):
+    """Create a legacy CSV run folder and return its path."""
+    run_dir = data_dir / run_id
+    run_dir.mkdir(parents=True)
+
+    metadata = {
+        "run_info": {
+            "date": "2025-10-06",
+            "start_time": "10:41:00",
+            "run_type": "permeation_exp",
+            "furnace_setpoint": 500,
+            material_key: material,
+            "coating": "TiN",
+        },
+        "gauges": {"WGM701": "info"},
+        "thermocouples": {"TC1": "info"},
+    }
+    with open(run_dir / store.METADATA_FILENAME, "w") as f:
+        json.dump(metadata, f)
+
+    data = {
+        "RealTimestamp": [
+            f"2025-10-06 10:41:{i:02d}.{i * 111 % 1000:03d}" for i in range(n_rows)
+        ]
+    }
+    if with_temperature:
+        data["Local_temperature (C)"] = [20.0 + i * 0.1 for i in range(n_rows)]
+        data["furnace_thermocouple_Voltage (mV)"] = [
+            1.234567890123 + i for i in range(n_rows)
+        ]
+    for j, col in enumerate(GAUGE_COLUMNS):
+        data[col] = [j + i * 0.0012345678901234 for i in range(n_rows)]
+
+    pd.DataFrame(data).to_csv(run_dir / store.LEGACY_CSV_FILENAME, index=False)
+    return run_dir
+
+
+@pytest.fixture
+def data_dir(tmp_path):
+    """run_data with one legacy CSV run and one converted Parquet run."""
+    root = tmp_path / "run_data"
+    _write_run(root, "25.10.06_run_1_10h41", material="steel")
+    run2 = _write_run(
+        root,
+        "25.10.07_run_1_08h16",
+        with_temperature=True,
+        material_key="sample_material",
+        material="aluminum",
+    )
+    store.convert_run(run2, delete_csv=True)
+    return root
+
+
+@pytest.fixture
+def store_mode(tmp_path, monkeypatch):
+    """Point db at an isolated cache with no pinned database (store mode)."""
+    monkeypatch.delenv(db.DB_ENV_VAR, raising=False)
+    monkeypatch.delenv(db.CATALOGUE_ENV_VAR, raising=False)
+    monkeypatch.setattr(db, "DB_PATH", None)
+    monkeypatch.setattr(db, "CATALOGUE_PATH", None)
+    cache = tmp_path / "cache"
+    monkeypatch.setattr(db, "_cache_dir", lambda: cache)
+    monkeypatch.setattr(db, "_CATALOGUE_MEMO", {})
+    return cache
+
+
+# --- conversion -------------------------------------------------------------
+
+
+def test_convert_run_round_trip_is_exact(tmp_path):
+    run_dir = _write_run(tmp_path / "run_data", "25.10.06_run_1_10h41", n_rows=50)
+    original = pd.read_csv(run_dir / store.LEGACY_CSV_FILENAME)
+
+    parquet_path = store.convert_run(run_dir)
+
+    back = pd.read_parquet(parquet_path)
+    assert len(back) == 50
+    for col in GAUGE_COLUMNS:
+        assert back[col].equals(original[col])  # bit-identical float64
+    assert pd.api.types.is_datetime64_any_dtype(back["RealTimestamp"])
+    assert back["RealTimestamp"].iloc[1] == pd.Timestamp("2025-10-06 10:41:01.111")
+
+
+def test_convert_run_keeps_csv_by_default(tmp_path):
+    run_dir = _write_run(tmp_path / "run_data", "25.10.06_run_1_10h41")
+    store.convert_run(run_dir)
+    assert (run_dir / store.LEGACY_CSV_FILENAME).exists()
+
+
+def test_convert_run_deletes_csv_when_asked(tmp_path):
+    run_dir = _write_run(tmp_path / "run_data", "25.10.06_run_1_10h41")
+    store.convert_run(run_dir, delete_csv=True)
+    assert not (run_dir / store.LEGACY_CSV_FILENAME).exists()
+    assert (run_dir / store.MEASUREMENTS_FILENAME).exists()
+
+
+def test_convert_preserves_extra_channels(tmp_path):
+    run_dir = _write_run(
+        tmp_path / "run_data", "25.10.06_run_1_10h41", with_temperature=True
+    )
+    store.convert_run(run_dir, delete_csv=True)
+    df = store.read_measurements(run_dir)
+    assert "Local_temperature (C)" in df.columns
+    assert "furnace_thermocouple_Voltage (mV)" in df.columns
+
+
+def test_read_measurements_same_for_both_formats(tmp_path):
+    run_dir = _write_run(tmp_path / "run_data", "25.10.06_run_1_10h41", n_rows=10)
+    from_csv = store.read_measurements(run_dir)
+    store.convert_run(run_dir, delete_csv=True)
+    from_parquet = store.read_measurements(run_dir)
+    pd.testing.assert_frame_equal(from_csv, from_parquet, check_dtype=False)
+
+
+def test_data_file_missing_raises(tmp_path):
+    empty = tmp_path / "run_data" / "25.10.06_run_1_10h41"
+    empty.mkdir(parents=True)
+    with pytest.raises(FileNotFoundError):
+        store.data_file(empty)
+
+
+def test_convert_cli_converts_whole_directory(tmp_path, capsys):
+    root = tmp_path / "run_data"
+    _write_run(root, "25.10.06_run_1_10h41")
+    _write_run(root, "25.10.07_run_1_08h16")
+    assert store.main(["convert", str(root), "--delete-csv"]) == 0
+    assert (root / "25.10.06_run_1_10h41" / store.MEASUREMENTS_FILENAME).exists()
+    assert not (root / "25.10.06_run_1_10h41" / store.LEGACY_CSV_FILENAME).exists()
+    assert "Converted 2 run(s)" in capsys.readouterr().out
+
+
+# --- catalogue --------------------------------------------------------------
+
+
+def test_build_catalogue_fields(data_dir):
+    cat = store.build_catalogue(data_dir)
+
+    assert list(cat["run_id"]) == ["25.10.06_run_1_10h41", "25.10.07_run_1_08h16"]
+    run1 = cat.iloc[0]
+    assert run1["material"] == "steel"
+    assert run1["furnace_setpoint"] == 500
+    assert run1["data_file"] == store.LEGACY_CSV_FILENAME
+    assert set(run1["channels"]) == set(GAUGE_COLUMNS)
+
+    # v1.3 metadata: material falls back to sample_material; extra channels listed
+    run2 = cat.iloc[1]
+    assert run2["material"] == "aluminum"
+    assert run2["data_file"] == store.MEASUREMENTS_FILENAME
+    assert "Local_temperature (C)" in list(run2["channels"])
+    assert run2["n_measurements"] == 3
+
+    # checksums match the actual files; metadata JSON is complete
+    path = data_dir / run2["run_id"] / run2["data_file"]
+    assert run2["sha256"] == hashlib.sha256(path.read_bytes()).hexdigest()
+    assert json.loads(run2["metadata"])["run_info"]["run_type"] == "permeation_exp"
+
+
+def test_build_catalogue_writes_parquet(data_dir, tmp_path):
+    out = tmp_path / "catalogue.parquet"
+    store.build_catalogue(data_dir, output=out)
+    assert pd.read_parquet(out)["run_id"].tolist() == [
+        "25.10.06_run_1_10h41",
+        "25.10.07_run_1_08h16",
+    ]
+
+
+# --- store-mode API ---------------------------------------------------------
+
+
+def test_catalogue_store_mode_from_local_dir(data_dir, store_mode, monkeypatch):
+    monkeypatch.setattr(db, "RUN_DATA_DIR", data_dir)
+    cat = db.catalogue()
+    assert len(cat) == 2
+    assert "channels" in cat.columns
+
+
+def test_load_store_mode_from_local_dir(data_dir, store_mode, monkeypatch):
+    monkeypatch.setattr(db, "RUN_DATA_DIR", data_dir)
+    df = db.load("25.10.07_run_1_08h16")
+    assert (df["run_id"] == "25.10.07_run_1_08h16").all()
+    assert "Local_temperature (C)" in df.columns
+    assert pd.api.types.is_datetime64_any_dtype(df["RealTimestamp"])
+
+
+def test_load_metadata_store_mode(data_dir, store_mode, monkeypatch):
+    monkeypatch.setattr(db, "RUN_DATA_DIR", data_dir)
+    metadata = db.load_metadata("25.10.06_run_1_10h41")
+    assert metadata["run_info"]["furnace_setpoint"] == 500
+
+
+def test_load_metadata_store_mode_missing_run(data_dir, store_mode, monkeypatch):
+    monkeypatch.setattr(db, "RUN_DATA_DIR", data_dir)
+    with pytest.raises(KeyError):
+        db.load_metadata("99.99.99_run_9_99h99")
+
+
+def test_load_filtered_store_mode_aligns_channels(data_dir, store_mode, monkeypatch):
+    monkeypatch.setattr(db, "RUN_DATA_DIR", data_dir)
+    df = db.load_filtered(run_type="permeation_exp")
+    assert set(df["run_id"]) == {"25.10.06_run_1_10h41", "25.10.07_run_1_08h16"}
+    # run 1 has no temperature channel: aligned as NaN
+    run1_rows = df[df["run_id"] == "25.10.06_run_1_10h41"]
+    assert run1_rows["Local_temperature (C)"].isna().all()
+
+
+def test_load_filtered_store_mode_by_material(data_dir, store_mode, monkeypatch):
+    monkeypatch.setattr(db, "RUN_DATA_DIR", data_dir)
+    df = db.load_filtered(material="aluminum")
+    assert set(df["run_id"]) == {"25.10.07_run_1_08h16"}
+
+
+def test_load_filtered_unknown_filter_raises(data_dir, store_mode, monkeypatch):
+    monkeypatch.setattr(db, "RUN_DATA_DIR", data_dir)
+    with pytest.raises(ValueError, match="Unknown filter"):
+        db.load_filtered(substrate="unknown")
+
+
+def test_load_filtered_no_matches_returns_empty(data_dir, store_mode, monkeypatch):
+    monkeypatch.setattr(db, "RUN_DATA_DIR", data_dir)
+    assert db.load_filtered(material="unobtainium").empty
+
+
+# --- per-run download and caching -------------------------------------------
+
+
+@pytest.fixture
+def remote(data_dir, store_mode, monkeypatch, tmp_path):
+    """Simulate a remote repo: no local run_data, runs served via _fetch."""
+    monkeypatch.setattr(db, "RUN_DATA_DIR", tmp_path / "no_such_dir")
+
+    cat_path = tmp_path / "catalogue.parquet"
+    store.build_catalogue(data_dir, output=cat_path)
+    monkeypatch.setattr(db, "CATALOGUE_PATH", cat_path)
+
+    calls = []
+
+    def fake_fetch(url):
+        calls.append(url)
+        prefix = f"{db.RAW_DATA_URL}/"
+        if not url.startswith(prefix):
+            raise urllib.error.URLError("unexpected url")
+        run_id, name = url[len(prefix) :].split("/")
+        path = data_dir / run_id / name
+        if not path.exists():
+            raise urllib.error.HTTPError(url, 404, "Not Found", None, None)
+        return path.read_bytes()
+
+    monkeypatch.setattr(db, "_fetch", fake_fetch)
+    return calls
+
+
+def test_load_downloads_verifies_and_caches(remote, store_mode):
+    df = db.load("25.10.07_run_1_08h16")
+    assert len(df) == 3
+    cached = store_mode / "runs" / "25.10.07_run_1_08h16" / store.MEASUREMENTS_FILENAME
+    assert cached.exists()
+
+    # Second load comes from the cache: no new fetches
+    n_calls = len(remote)
+    df2 = db.load("25.10.07_run_1_08h16")
+    assert len(remote) == n_calls
+    pd.testing.assert_frame_equal(df, df2)
+
+
+def test_load_download_checksum_mismatch_raises(remote, store_mode, monkeypatch):
+    real_fetch = db._fetch
+    monkeypatch.setattr(db, "_fetch", lambda url: real_fetch(url) + b"tampered")
+    with pytest.raises(RuntimeError, match="checksum"):
+        db.load("25.10.07_run_1_08h16")
+
+
+def test_load_missing_run_raises(remote):
+    with pytest.raises(FileNotFoundError, match=r"99\.99\.99_run_9_99h99"):
+        db.load("99.99.99_run_9_99h99")
+
+
+def test_update_catalogue_downloads_and_caches(
+    store_mode, data_dir, tmp_path, monkeypatch
+):
+    cat_path = tmp_path / "catalogue.parquet"
+    store.build_catalogue(data_dir, output=cat_path)
+    raw = cat_path.read_bytes()
+    manifest = {
+        "catalogue_sha256": hashlib.sha256(raw).hexdigest(),
+        "runs": 2,
+    }
+    responses = {
+        f"{db.DATA_RELEASE_URL}/manifest.json": json.dumps(manifest).encode(),
+        f"{db.DATA_RELEASE_URL}/{store.CATALOGUE_FILENAME}": raw,
+    }
+    monkeypatch.setattr(db, "_fetch", lambda url: responses[url])
+
+    path = db.update_catalogue()
+    assert pd.read_parquet(path)["run_id"].tolist() == [
+        "25.10.06_run_1_10h41",
+        "25.10.07_run_1_08h16",
+    ]
+
+    # Catalogue-less release raises a helpful error
+    responses[f"{db.DATA_RELEASE_URL}/manifest.json"] = json.dumps({"runs": 2}).encode()
+    (store_mode / "catalogue_manifest.json").unlink()
+    with pytest.raises(RuntimeError, match="does not include a catalogue"):
+        db.update_catalogue()
+
+
+def test_update_catalogue_checksum_mismatch_raises(store_mode, monkeypatch):
+    manifest = {"catalogue_sha256": "0" * 64}
+    responses = {
+        f"{db.DATA_RELEASE_URL}/manifest.json": json.dumps(manifest).encode(),
+        f"{db.DATA_RELEASE_URL}/{store.CATALOGUE_FILENAME}": b"not a catalogue",
+    }
+    monkeypatch.setattr(db, "_fetch", lambda url: responses[url])
+    with pytest.raises(RuntimeError, match="checksum mismatch"):
+        db.update_catalogue()


### PR DESCRIPTION
Phase 1 of the storage redesign: readers understand Parquet before any writer produces it. Nothing in `run_data/` changes in this PR — the backfill converting the 105 existing runs is stacked on top as a follow-up PR.

## What changes

- **`store.py` (new)**: the per-run storage layer — `read_measurements()` reads a run folder in either format (Parquet preferred, legacy CSV fallback); `convert_run()` converts CSV→zstd-Parquet and verifies an exact round-trip (row counts, columns, bit-identical float64) before optionally deleting the CSV; `build_catalogue()` scans `run_data/` into a catalogue with normalised metadata fields (material falls back to v1.3's `sample_material`), per-run `channels` lists, measurement counts, and data-file sha256s. CLI: `python -m shield_data.store convert|catalogue`.
- **`db.py`**: same public API, store-backed. `catalogue()` resolves local checkout → pinned/cached catalogue → download from `data-latest`. `load(run_id)` fetches just that run from the repo raw URLs, verifies the catalogue checksum, and caches per-user. `load_filtered()` downloads only matching runs and aligns channels (NaN where a run didn't record one). New `update_catalogue()` export.
- **Legacy mode preserved**: pinning `SHIELD_DATA_DB` (or `db.DB_PATH`, as all existing tests do) keeps the exact old SQLite behaviour, old column names included. `build_db.py` still builds the legacy DB and now ingests either storage format, so the deprecation-window DB keeps working after the backfill.
- **CI**: `validate_data.yml` accepts `measurements.parquet` or legacy CSV per run (exactly one), requires `RealTimestamp` + ≥1 channel + rows > 0; required status-check job names unchanged. `build_db_release.yml` additionally builds `catalogue.parquet` and attaches it to `data-latest` with its sha256 in the manifest.
- pyarrow becomes a dependency; README rewritten around the new model.

## Why (measured on the live repo)

- The largest run is an 81.6 MB CSV — one long run from GitHub's hard 100 MB file limit. Parquet/zstd: 7.5 MB (10.9×).
- Consumers currently download the whole 98 MB DB to touch any run; now `load()` moves only that run's file.
- 61 of 105 runs record temperature channels that the hardcoded 4-column SQLite ingest silently drops; Parquet keeps every recorded channel and future instruments need no migration.

## Tests

160 pass locally (20 new in `test_store.py`: conversion round-trip, catalogue fields, store-mode API, download/checksum/cache paths). `ruff format` + `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)